### PR TITLE
Use tor-v3-vanity Docker image locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,11 @@ RUN apt-get update \
 
 # Setup our environment & deps
 ADD ./mnt-run.sh ${HOME}/mnt-run.sh
+RUN chmod +x ${HOME}/mnt-run.sh
 ENV INSTALL_PATH=/root
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y curl apt-utils;\
-apt-get install -y git s3fs build-essential;\
+apt-get install -y git build-essential;\
 \
 # Install tor-v3-address (CUDA .onion generator) \
 git clone https://github.com/dr-bonez/tor-v3-vanity ${INSTALL_PATH}/tor-v3-vanity;\
@@ -38,4 +39,4 @@ cargo install ptx-linker;\
 cargo +nightly install --path .
 
 # Set script that will execute when end-user runs container
-ENTRYPOINT ["~/mnt-space-run.sh"]
+ENTRYPOINT ["/root/mnt-run.sh"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # tor-v3-vanity for Docker
 
-Deploy the GPU-powered tor-v3-vanity .onion generator as a Docker image. This means you can now use cost-effective GPU rental services like vast.ai which allow your to deploy Docker images.
+Deploy the GPU-powered tor-v3-vanity .onion generator as a Docker image. Originally intended for cloud GPU rentals, the image can now be used comfortably on a local Ubuntu host.
 
 ## Usage
+
+Build the image:
+
+```
+docker build -t tor-v3-vanity .
+```
+
+Run with your desired prefix and a local directory to store generated keys:
+
+```
+mkdir -p keys
+docker run --gpus all -e ONION_PREFIX=example -v "$(pwd)/keys:/root/tor-v3-vanity/mykeys" tor-v3-vanity
+```
+
+The container writes keys to `/root/tor-v3-vanity/mykeys`, which is bound to `./keys` on the host in this example.
 

--- a/mnt-run.sh
+++ b/mnt-run.sh
@@ -1,30 +1,16 @@
 #!/bin/bash
+set -e
 
+# Default installation and output locations
+INSTALL_PATH=${INSTALL_PATH:-/root}
+OUTPUT_DIR=${OUTPUT_DIR:-${INSTALL_PATH}/tor-v3-vanity/mykeys}
 
-# Specify required environment variables
-ENV_VARS=(
-    "DO_KEY"
-    "DO_SECRET"
-    "DO_SPACE"
-    "DO_REGION"
-    "ONION_PREFIX"
-    "INSTALL_PATH"
-)
+# Ensure an onion prefix has been provided
+if [[ -z "$ONION_PREFIX" ]]; then
+    echo "Error: ONION_PREFIX is not set" >&2
+    exit 1
+fi
 
-# Check that all necessary environment varialbes are set
-for e in "${ENV_VARS[@]}"; do
-    [[ -v $e ]] || { echo "Error $e"; exit 0; }
-done
-
-# Add DO Spaces API key & secret from env
-echo "$DO_KEY:$DO_SECRET" > ~/.passwd-s3fs && chmod 600 ~/.passwd-s3fs;\
-
-# Mount the DO space (s3 bucket)
-s3fs "${DO_SPACE}" ${INSTALL_PATH}/tor-v3-vanity/mykeys \
--o passwd_file=~/.passwd-s3fs \
--o "url=https://${DO_REGION}.digitaloceanspaces.com/" \
--o use_path_request_style \
-&& \
-
-# Run the CUDA .onion v3 generator storing results in DO space/bucket
-~/tor-v3-vanity/t3v --dst "${INSTALL_PATH}/tor-v3-vanity/mykeys" "$ONION_PREFIX";
+# Create destination directory and run the generator
+mkdir -p "$OUTPUT_DIR"
+~/tor-v3-vanity/t3v --dst "$OUTPUT_DIR" "$ONION_PREFIX"


### PR DESCRIPTION
## Summary
- strip DigitalOcean-specific tooling and use a simple runtime script
- set Docker entrypoint to the local runner and drop s3fs dependency
- document how to build and run the image on an Ubuntu host

## Testing
- `bash -n mnt-run.sh`
- `docker build .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_6893618b376c83318e4ffba3da9c1721