### PR TITLE
feat: add podman support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,28 @@
-# tor-v3-vanity for Docker
+# tor-v3-vanity for Containers
 
-Deploy the GPU-powered tor-v3-vanity .onion generator as a Docker image. Originally intended for cloud GPU rentals, the image can now be used comfortably on a local Ubuntu host.
+Deploy the GPU-powered tor-v3-vanity .onion generator as a container image. Originally intended for cloud GPU rentals, the image can now be used comfortably on a local Ubuntu host with either Docker or Podman.
 
 ## Usage
 
-Build the image:
+The script `container.sh` automatically selects `podman` when available, falling back to `docker`. You can override the choice by setting the `CONTAINER_ENGINE` environment variable.
+
+### Build the image
 
 ```
-docker build -t tor-v3-vanity .
+./container.sh build -t tor-v3-vanity .
 ```
 
-Run with your desired prefix and a local directory to store generated keys:
+### Run with your desired prefix and a local directory to store generated keys
 
 ```
 mkdir -p keys
-docker run --gpus all -e ONION_PREFIX=example -v "$(pwd)/keys:/root/tor-v3-vanity/mykeys" tor-v3-vanity
+./container.sh run --rm --gpus all -e ONION_PREFIX=example -v "$(pwd)/keys:/root/tor-v3-vanity/mykeys" tor-v3-vanity
 ```
 
-The container writes keys to `/root/tor-v3-vanity/mykeys`, which is bound to `./keys` on the host in this example.
+For Podman users with NVIDIA GPUs, you may need to include the NVIDIA container hooks:
 
+```
+./container.sh run --hooks-dir=/usr/share/containers/oci/hooks.d --device nvidia.com/gpu=all -e ONION_PREFIX=example -v "$(pwd)/keys:/root/tor-v3-vanity/mykeys" tor-v3-vanity
+```
+
+The container writes keys to `/root/tor-v3-vanity/mykeys`, which is bound to `./keys` on the host in these examples.

--- a/container.sh
+++ b/container.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Wrapper script to use either podman or docker as container engine.
+set -e
+
+# If CONTAINER_ENGINE is set, use it. Otherwise, prefer podman if available.
+ENGINE="${CONTAINER_ENGINE}"
+if [ -z "$ENGINE" ]; then
+  if command -v podman >/dev/null 2>&1; then
+    ENGINE=podman
+  elif command -v docker >/dev/null 2>&1; then
+    ENGINE=docker
+  else
+    echo "Error: neither podman nor docker was found in PATH" >&2
+    exit 1
+  fi
+fi
+
+# Execute the chosen engine with all passed arguments.
+exec "$ENGINE" "$@"


### PR DESCRIPTION
## Summary
- add container.sh to automatically choose podman or docker
- document how to build/run with either engine

## Testing
- `shellcheck container.sh mnt-run.sh` *(fails: command not found)*
- `apt-get update && apt-get install -y shellcheck` *(fails: repository is not signed)*
- `bash -n container.sh mnt-run.sh`


------
https://chatgpt.com/codex/tasks/task_e_6893713312d0833195d2b86cd464ace2