### PR TITLE
Fix Dockerfile path for mnt-run script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update \
  && apt-get install -yq cuda-libraries-dev-10-0
 
 # Setup our environment & deps
-ADD ./mnt-run.sh ${HOME}/mnt-run.sh
-RUN chmod +x ${HOME}/mnt-run.sh
+COPY mnt-run.sh /root/mnt-run.sh
+RUN chmod +x /root/mnt-run.sh
 ENV INSTALL_PATH=/root
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y curl apt-utils;\


### PR DESCRIPTION
## Summary
- copy mnt-run.sh into /root explicitly and mark it executable to avoid missing file errors during image build

## Testing
- `docker build .` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6893a96fcac48331be74ebb6017177d7