### PR TITLE
fix: copy mnt-run using absolute path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update \
  && apt-get install -yq cuda-libraries-dev-10-0
 
 # Setup our environment & deps
-ADD ./mnt-run.sh ${HOME}/mnt-run.sh
-RUN chmod +x ${HOME}/mnt-run.sh
+ADD mnt-run.sh /root/mnt-run.sh
+RUN chmod +x /root/mnt-run.sh
 ENV INSTALL_PATH=/root
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y curl apt-utils;\


### PR DESCRIPTION
## Summary
- fix Dockerfile to add mnt-run.sh to root using an absolute path

## Testing
- `podman build --no-cache -t test .` *(fails: creating build container: copying system image from manifest list: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6893abd11cec833186a0314e2ae529dd