### PR TITLE
Update Rust toolchain and ptx-linker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
  && apt-get install -y git build-essential
 
 # Install rust and NVPTX toolchain
-ARG RUST_VERSION=nightly-2020-01-02
-ARG PTX_LINKER_VERSION=0.9.0
+ARG RUST_VERSION=nightly
+ARG PTX_LINKER_VERSION=0.9.1
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_VERSION}
 ENV PATH /root/.cargo/bin:$PATH
 RUN rustup target add nvptx64-nvidia-cuda --toolchain ${RUST_VERSION}


### PR DESCRIPTION
## Summary
- use the latest Rust nightly toolchain
- update ptx-linker to 0.9.1 so it can compile with modern crates

## Testing
- `cargo +nightly install ptx-linker --version 0.9.1` *(fails: unable to parse `llvm-sys` crate)*

------
https://chatgpt.com/codex/tasks/task_e_6893bf7c7da4833183941e04a87952ca